### PR TITLE
Move Message attribute to first position

### DIFF
--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
@@ -76,14 +76,14 @@ namespace Serilog.Sinks.Loggly
             var isHttpTransport = LogglyConfig.Instance.Transport.LogTransport == LogTransport.Https;
             logglyEvent.Syslog.Level = ToSyslogLevel(logEvent);
 
+            logglyEvent.Data.AddIfAbsent("Message", logEvent.RenderMessage(_formatProvider));
+
             foreach (var key in logEvent.Properties.Keys)
             {
                 var propertyValue = logEvent.Properties[key];
                 var simpleValue = LogglyPropertyFormatter.Simplify(propertyValue);
                 logglyEvent.Data.AddIfAbsent(key, simpleValue);
             }
-
-            logglyEvent.Data.AddIfAbsent("Message", logEvent.RenderMessage(_formatProvider));
 
             if (isHttpTransport)
             {


### PR DESCRIPTION
Improves readability of Loggly searches since the human-readable message comes first.

Shouldn't have any negative side effects since JSON object elements aren't supposed to be ordered, so this won't affect filtering/search within Loggly.
