### PR TITLE
Bug fix: Retain Serilog event timestamp rather than time sent to Loggly

### DIFF
--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
@@ -71,7 +71,7 @@ namespace Serilog.Sinks.Loggly
 
         private LogglyEvent CreateLogglyEvent(LogEvent logEvent)
         {
-            var logglyEvent = new LogglyEvent();
+            var logglyEvent = new LogglyEvent() { Timestamp = logEvent.Timestamp };
 
             var isHttpTransport = LogglyConfig.Instance.Transport.LogTransport == LogTransport.Https;
             logglyEvent.Syslog.Level = ToSyslogLevel(logEvent);


### PR DESCRIPTION
**Issue**
Events sent to Loggly via this sink have incorrect timestamps within Loggly - the time they (actually their whole batch) were sent to Loggly, rather than the time they were actually logged. With large batches or event queues, this can be quite a problematic data loss.

**Cause**
Currently, the Serilog=>Loggly event translation drops the event's actual timestamp by omission - the Loggly event keeps its constructor-default of DateTimeOffset.UtcNow. Since the translation isn't done until a batch is ready to send, this effectively re-timestamps events (actually whole batches of events) with their sending time.

**Fix**
The fix is trivial - explicitly set the Loggly event timestamp, using the Serilog event timestamp.