### PR TITLE
Sign dll

### DIFF
--- a/src/Serilog.Sinks.Loggly/project.json
+++ b/src/Serilog.Sinks.Loggly/project.json
@@ -14,7 +14,9 @@
     "Serilog": "2.0.0",
     "Serilog.Sinks.PeriodicBatching": "2.0.0"
   },
-
+  "buildOptions": {
+    "keyFile": "../../assets/Serilog.snk"
+  },
   "frameworks": {
     "net45": {
     },


### PR DESCRIPTION
Although the signature key was on the project, the dll was not being signed at the end.