### PR TITLE
Loggly-csharp reference updated.

### DIFF
--- a/src/Serilog.Sinks.Loggly/project.json
+++ b/src/Serilog.Sinks.Loggly/project.json
@@ -9,7 +9,7 @@
     "iconUrl": "http://serilog.net/images/serilog-sink-nuget.png"
   },
   "dependencies": {
-    "loggly-csharp": "4.6.0.2",
+    "loggly-csharp": "4.6.0.5",
     "Newtonsoft.Json": "9.0.1",
     "Serilog": "2.0.0",
     "Serilog.Sinks.PeriodicBatching": "2.0.0"


### PR DESCRIPTION
This update was done due to the fact the previous reference of Loggly-csharp was not signed (the dll's didn't had strong name).