### PR TITLE
Drop invalid messages

### DIFF
--- a/src/Serilog.Sinks.Loggly/LoggerConfigurationLogglyExtensions.cs
+++ b/src/Serilog.Sinks.Loggly/LoggerConfigurationLogglyExtensions.cs
@@ -47,6 +47,7 @@ namespace Serilog
         /// <param name="retainedInvalidPayloadsLimitBytes">A soft limit for the number of bytes to use for storing failed requests.  
         /// The limit is soft in that it can be exceeded by any single error payload, but in that case only that single error
         /// payload will be retained.</param>
+        /// <param name="retainedFileCountLimit">number of files to retain for the buffer</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Loggly(
@@ -59,7 +60,8 @@ namespace Serilog
             long? bufferFileSizeLimitBytes = null,
             long? eventBodyLimitBytes = 1024 * 1024,
             LoggingLevelSwitch controlLevelSwitch = null,
-            long? retainedInvalidPayloadsLimitBytes = null)
+            long? retainedInvalidPayloadsLimitBytes = null,
+            int? retainedFileCountLimit = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (bufferFileSizeLimitBytes.HasValue && bufferFileSizeLimitBytes < 0)
@@ -83,6 +85,7 @@ namespace Serilog
                     eventBodyLimitBytes,
                     controlLevelSwitch,
                     retainedInvalidPayloadsLimitBytes, 
+                    retainedFileCountLimit,
                     formatProvider);
             }
 

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/DurableLogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/DurableLogglySink.cs
@@ -40,7 +40,7 @@ namespace Serilog.Sinks.Loggly
             if (bufferBaseFilename == null) throw new ArgumentNullException(nameof(bufferBaseFilename));
 
             //use a consistent UTF encoding with BOM so no confusion will exist when reading / deserializing
-            var encoding = new UTF8Encoding(true);
+            var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier:false);
 
             //handles sending events to Loggly's API through LogglyClient and manages the pending list
             _shipper = new HttpLogShipper(

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/DurableLogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/DurableLogglySink.cs
@@ -39,7 +39,7 @@ namespace Serilog.Sinks.Loggly
         {
             if (bufferBaseFilename == null) throw new ArgumentNullException(nameof(bufferBaseFilename));
 
-            //use a consistent UT( encoding with BOM so no confusion will exist
+            //use a consistent UTF encoding with BOM so no confusion will exist when reading / deserializing
             var encoding = new UTF8Encoding(true);
 
             //handles sending events to Loggly's API through LogglyClient and manages the pending list

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/DurableLogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/DurableLogglySink.cs
@@ -33,9 +33,14 @@ namespace Serilog.Sinks.Loggly
             long? eventBodyLimitBytes,
             LoggingLevelSwitch levelControlSwitch,
             long? retainedInvalidPayloadsLimitBytes,
-            IFormatProvider formatProvider = null)
+            int? retainedFileCountLimit = null,
+            IFormatProvider formatProvider = null
+            )
         {
             if (bufferBaseFilename == null) throw new ArgumentNullException(nameof(bufferBaseFilename));
+
+            //use a consistent UT( encoding with BOM so no confusion will exist
+            var encoding = new UTF8Encoding(true);
 
             //handles sending events to Loggly's API through LogglyClient and manages the pending list
             _shipper = new HttpLogShipper(
@@ -44,15 +49,16 @@ namespace Serilog.Sinks.Loggly
                 period, 
                 eventBodyLimitBytes, 
                 levelControlSwitch,
-                retainedInvalidPayloadsLimitBytes);
+                retainedInvalidPayloadsLimitBytes,
+                encoding);
 
             //writes events to the file to support connection recovery
             _sink = new RollingFileSink(
                 bufferBaseFilename + "-{Date}.json",
                 new LogglyFormatter(formatProvider), //serializes as LogglyEvent
                 bufferFileSizeLimitBytes,
-                null,
-                Encoding.UTF8);
+                retainedFileCountLimit,
+                encoding);
         }
 
         public void Dispose()

--- a/src/Serilog.Sinks.Loggly/project.json
+++ b/src/Serilog.Sinks.Loggly/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.1-*",
+  "version": "4.0.2-*",
   "description": "Serilog sink for Loggly.com service",
   "authors": [ "Serilog Contributors", "Michiel van Oudheusden" ],
   "packOptions": {


### PR DESCRIPTION
We noticed some miss behavior with the durable logging feature. 

For some reason, we came across a situation in which the same _set_ of messages where repeatedly set to Loggly. The exact cause has not been determined but we are sure it is related to the durable logging feature - the messages being sent where the same set in the first buffer file on the misbehaving machine. We also noticed there was a single "invalid-*" file with the same set of messages that we identified where repeated. This was making our account pass the daily message cap from our Loggly service plan.

During the debugging session, using the same set of files, an error was occurring when resuming the read operation of the buffer file: the position counter in the bookmark file was NOT at the start of the line that was to be read. It was a couple of bytes off (forward), which might have been related to a (misinterpreted) BOM marker. UTF8 is passed into the RollingFileSink for writing messages and UTF8 encoding is used to read the messages in the buffer file, though they are not the same instance of encoders. I suspected that, for some reason, one could be considering the BOM and the other operation not, so I decided to use the Encoding constructor and pass the instance into each of the classes (HttpLogShipper for reading and RollingFileSink for writing).

Even with this in place, it wasn't possible to recover from the error. Every time the read operation was run, there was an attempt to read an incomplete line from the file. Since the JSON contained in it was incomplete, it could not be deserialized. The error in the deserialization process bubbled up past the point where the bookmark would be updated, so at each cycle, there was an attempt to read the same line incorrectly.

To avoid this, the PR includes message dropping for incorrectly formatted JSON messages. If the line is read incorrectly, or fails the deserialization, the message is dropped and the marker moves forward to the correct position. The next line can then be read and deserialized correctly.

This PR also includes an argument to control the RollingFile retention limit, requested in #13 