### PR TITLE
Curly bracket not escaped in format string

### DIFF
--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/HttpLogShipper.cs
@@ -324,7 +324,7 @@ namespace Serilog.Sinks.Loggly
                         //that follows are, therefore, attempts to preserve the logging functionality active, though some 
                         // events may be dropped in the process.
                         SelfLog.WriteLine(
-                            "Event JSON representation does not start with the expected '{' character. "+
+                            "Event JSON representation does not start with the expected '{{' character. "+
                             "This may be related to a BOM issue in the buffer file. Event will be dropped; data: {0}",
                              nextLine);
                     }


### PR DESCRIPTION
This line tries to log errors when a curly bracket is not found at the start of a line, but the string used for the error message is bad and throws an exception from the curly bracket not being escaped.

I've noticed events can stop getting sent to loggly if I use the buffer file and I have to delete the buffer file before any events get sent, even after restarting my process.  I think this section of code could use some improved error handling but I don't know the code well enough yet to tackle that.