### PR TITLE
LogglyClient configuration and auto added log fields

### DIFF
--- a/src/Serilog.Sinks.Loggly/LoggerConfigurationLogglyExtensions.cs
+++ b/src/Serilog.Sinks.Loggly/LoggerConfigurationLogglyExtensions.cs
@@ -48,6 +48,7 @@ namespace Serilog
         /// The limit is soft in that it can be exceeded by any single error payload, but in that case only that single error
         /// payload will be retained.</param>
         /// <param name="retainedFileCountLimit">number of files to retain for the buffer. If defined, this also controls which records 
+        /// <param name="logglyConfig">Used to configure underlying LogglyClient programmaticaly. Otherwise use app.Config.</param>
         /// in the buffer get sent to the remote Loggly instance</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
@@ -62,7 +63,8 @@ namespace Serilog
             long? eventBodyLimitBytes = 1024 * 1024,
             LoggingLevelSwitch controlLevelSwitch = null,
             long? retainedInvalidPayloadsLimitBytes = null,
-            int? retainedFileCountLimit = null)
+            int? retainedFileCountLimit = null,
+            LogglyConfiguration logglyConfig = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (bufferFileSizeLimitBytes.HasValue && bufferFileSizeLimitBytes < 0)
@@ -74,7 +76,7 @@ namespace Serilog
 
             if (bufferBaseFilename == null)
             {
-                sink = new LogglySink(formatProvider, batchPostingLimit, defaultedPeriod);
+                sink = new LogglySink(formatProvider, batchPostingLimit, defaultedPeriod, logglyConfig);
             }
             else
             {
@@ -87,7 +89,8 @@ namespace Serilog
                     controlLevelSwitch,
                     retainedInvalidPayloadsLimitBytes, 
                     retainedFileCountLimit,
-                    formatProvider);
+                    formatProvider,
+                    logglyConfig);
             }
 
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);

--- a/src/Serilog.Sinks.Loggly/LoggerConfigurationLogglyExtensions.cs
+++ b/src/Serilog.Sinks.Loggly/LoggerConfigurationLogglyExtensions.cs
@@ -49,6 +49,7 @@ namespace Serilog
         /// payload will be retained.</param>
         /// <param name="retainedFileCountLimit">number of files to retain for the buffer. If defined, this also controls which records 
         /// <param name="logglyConfig">Used to configure underlying LogglyClient programmaticaly. Otherwise use app.Config.</param>
+        /// <param name="includes">Decides if the sink should include specific properties in the log message</param>
         /// in the buffer get sent to the remote Loggly instance</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
@@ -64,7 +65,8 @@ namespace Serilog
             LoggingLevelSwitch controlLevelSwitch = null,
             long? retainedInvalidPayloadsLimitBytes = null,
             int? retainedFileCountLimit = null,
-            LogglyConfiguration logglyConfig = null)
+            LogglyConfiguration logglyConfig = null,
+            LogIncludes includes = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (bufferFileSizeLimitBytes.HasValue && bufferFileSizeLimitBytes < 0)
@@ -76,7 +78,7 @@ namespace Serilog
 
             if (bufferBaseFilename == null)
             {
-                sink = new LogglySink(formatProvider, batchPostingLimit, defaultedPeriod, logglyConfig);
+                sink = new LogglySink(formatProvider, batchPostingLimit, defaultedPeriod, logglyConfig, includes);
             }
             else
             {
@@ -90,7 +92,8 @@ namespace Serilog
                     retainedInvalidPayloadsLimitBytes, 
                     retainedFileCountLimit,
                     formatProvider,
-                    logglyConfig);
+                    logglyConfig,
+                    includes);
             }
 
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);

--- a/src/Serilog.Sinks.Loggly/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Loggly/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyVersion("3.1.0.0")]
 
 [assembly: CLSCompliant(true)]
 

--- a/src/Serilog.Sinks.Loggly/Serilog.Sinks.Loggly.csproj
+++ b/src/Serilog.Sinks.Loggly/Serilog.Sinks.Loggly.csproj
@@ -16,6 +16,8 @@
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <RootNamespace>Serilog</RootNamespace>
+    <FileVersion>5.2.0.0</FileVersion>
+    <Version>5.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.Loggly/Serilog.Sinks.Loggly.csproj
+++ b/src/Serilog.Sinks.Loggly/Serilog.Sinks.Loggly.csproj
@@ -16,8 +16,6 @@
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <RootNamespace>Serilog</RootNamespace>
-    <FileVersion>5.2.0.0</FileVersion>
-    <Version>5.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.Loggly/Serilog.Sinks.Loggly.csproj
+++ b/src/Serilog.Sinks.Loggly/Serilog.Sinks.Loggly.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Serilog sink for Loggly.com service</Description>
-    <VersionPrefix>5.1.1</VersionPrefix>
+    <VersionPrefix>5.2.0</VersionPrefix>
     <Authors>Serilog Contributors;Michiel van Oudheusden</Authors>
     <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Loggly</AssemblyName>

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/DurableLogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/DurableLogglySink.cs
@@ -34,8 +34,8 @@ namespace Serilog.Sinks.Loggly
             LoggingLevelSwitch levelControlSwitch,
             long? retainedInvalidPayloadsLimitBytes,
             int? retainedFileCountLimit = null,
-            IFormatProvider formatProvider = null
-            )
+            IFormatProvider formatProvider = null,
+            LogglyConfiguration logglyConfiguration = null)
         {
             if (bufferBaseFilename == null) throw new ArgumentNullException(nameof(bufferBaseFilename));
 
@@ -51,7 +51,8 @@ namespace Serilog.Sinks.Loggly
                 levelControlSwitch,
                 retainedInvalidPayloadsLimitBytes,
                 encoding,
-                retainedFileCountLimit);
+                retainedFileCountLimit,
+                logglyConfiguration);
 
             //writes events to the file to support connection recovery
             _sink = new RollingFileSink(

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/DurableLogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/DurableLogglySink.cs
@@ -35,7 +35,8 @@ namespace Serilog.Sinks.Loggly
             long? retainedInvalidPayloadsLimitBytes,
             int? retainedFileCountLimit = null,
             IFormatProvider formatProvider = null,
-            LogglyConfiguration logglyConfiguration = null)
+            LogglyConfiguration logglyConfiguration = null,
+            LogIncludes includes = null)
         {
             if (bufferBaseFilename == null) throw new ArgumentNullException(nameof(bufferBaseFilename));
 
@@ -57,7 +58,7 @@ namespace Serilog.Sinks.Loggly
             //writes events to the file to support connection recovery
             _sink = new RollingFileSink(
                 bufferBaseFilename + "-{Date}.json",
-                new LogglyFormatter(formatProvider), //serializes as LogglyEvent
+                new LogglyFormatter(formatProvider, includes), //serializes as LogglyEvent
                 bufferFileSizeLimitBytes,
                 retainedFileCountLimit,
                 encoding);

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/HttpLogShipper.cs
@@ -43,7 +43,8 @@ namespace Serilog.Sinks.Loggly
         readonly IFileSystemAdapter _fileSystemAdapter = new FileSystemAdapter();
         readonly FileBufferDataProvider _bufferDataProvider;
         readonly InvalidPayloadLogger _invalidPayloadLogger;
-        
+        readonly LogglyConfigAdapter _adapter;
+
         public HttpLogShipper(
             string bufferBaseFilename, 
             int batchPostingLimit, 
@@ -52,13 +53,20 @@ namespace Serilog.Sinks.Loggly
             LoggingLevelSwitch levelControlSwitch, 
             long? retainedInvalidPayloadsLimitBytes, 
             Encoding encoding, 
-            int? retainedFileCountLimit)
+            int? retainedFileCountLimit,
+            LogglyConfiguration logglyConfiguration)
         {
             _batchPostingLimit = batchPostingLimit;
             _retainedFileCountLimit = retainedFileCountLimit;
 
             _controlledSwitch = new ControlledLevelSwitch(levelControlSwitch);
             _connectionSchedule = new ExponentialBackoffConnectionSchedule(period);
+
+            if (logglyConfiguration != null)
+            {
+                _adapter = new LogglyConfigAdapter();
+                _adapter.ConfigureLogglyClient(logglyConfiguration);
+            }
 
             _logglyClient = new LogglyClient(); //we'll use the loggly client instead of HTTP directly
 

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogIncludes.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogIncludes.cs
@@ -1,0 +1,20 @@
+﻿namespace Serilog.Sinks.Loggly
+{
+    public class LogIncludes
+    {
+        /// <summary>
+        /// Adds Serilog Level to all log events. Defaults to true.
+        /// </summary>
+        public bool IncludeLevel { get; set; } = true;
+
+        /// <summary>
+        /// Adds Serilog Message to all log events. Defaults to true.
+        /// </summary>
+        public bool IncludeMessage { get; set; } = true;
+
+        /// <summary>
+        /// Adds Serilog Exception to log events when an exception exists. Defaults to true.
+        /// </summary>
+        public bool IncludeExceptionWhenExists { get; set; } = true;
+    }
+}

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglyConfigAdapter.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglyConfigAdapter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Loggly.Config;
+
+namespace Serilog.Sinks.Loggly
+{
+    class LogglyConfigAdapter
+    {
+        public void ConfigureLogglyClient(LogglyConfiguration logglyConfiguration)
+        {
+            var config = LogglyConfig.Instance;
+
+            if (!string.IsNullOrWhiteSpace(logglyConfiguration.ApplicationName))
+                config.ApplicationName = logglyConfiguration.ApplicationName;
+
+            if (string.IsNullOrWhiteSpace(logglyConfiguration.CustomerToken))
+                throw new ArgumentNullException("CustomerToken", "CustomerToken is required");
+
+            config.CustomerToken = logglyConfiguration.CustomerToken;
+            config.IsEnabled = logglyConfiguration.IsEnabled;
+
+            foreach (var tag in logglyConfiguration.Tags)
+            {
+                config.TagConfig.Tags.Add(tag);
+            }
+
+            config.ThrowExceptions = logglyConfiguration.ThrowExceptions;
+
+            if (logglyConfiguration.LogTransport != TransportProtocol.Https)
+                config.Transport.LogTransport = (LogTransport)Enum.Parse(typeof(LogTransport), logglyConfiguration.LogTransport.ToString());
+
+            if (!string.IsNullOrWhiteSpace(logglyConfiguration.EndpointHostName))
+                config.Transport.EndpointHostname = logglyConfiguration.EndpointHostName;
+
+            if (logglyConfiguration.EndpointPort > 0 && logglyConfiguration.EndpointPort < ushort.MaxValue)
+                config.Transport.EndpointPort = logglyConfiguration.EndpointPort;
+
+            config.Transport.IsOmitTimestamp = logglyConfiguration.OmitTimestamp;
+            config.Transport = config.Transport.GetCoercedToValidConfig();
+        }
+    }
+}

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglyConfigAdapter.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglyConfigAdapter.cs
@@ -31,7 +31,7 @@ namespace Serilog.Sinks.Loggly
             if (!string.IsNullOrWhiteSpace(logglyConfiguration.EndpointHostName))
                 config.Transport.EndpointHostname = logglyConfiguration.EndpointHostName;
 
-            if (logglyConfiguration.EndpointPort > 0 && logglyConfiguration.EndpointPort < ushort.MaxValue)
+            if (logglyConfiguration.EndpointPort > 0 && logglyConfiguration.EndpointPort <= ushort.MaxValue)
                 config.Transport.EndpointPort = logglyConfiguration.EndpointPort;
 
             config.Transport.IsOmitTimestamp = logglyConfiguration.OmitTimestamp;

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglyConfiguration.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglyConfiguration.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+
+namespace Serilog.Sinks.Loggly
+{
+    public class LogglyConfiguration
+    {
+        public string ApplicationName { get; set; }
+        public string CustomerToken { get; set; }
+        public List<string> Tags { get; set; }
+        public bool IsEnabled { get; set; } = true;
+        public bool ThrowExceptions { get; set; }
+
+        /// <summary>
+        /// Defaults to Https
+        /// </summary>
+        public TransportProtocol LogTransport { get; set; }
+
+        /// <summary>
+        /// Defaults to logs-01.loggly.com
+        /// </summary>
+        public string EndpointHostName { get; set; }
+
+        /// <summary>
+        /// Defaults to default port for selected LogTransport.
+        /// E.g. https is 443, SyslogTcp/-Udp is 514 and SyslogSecure is 6514.
+        /// </summary>
+        public int EndpointPort { get; set; }
+
+        /// <summary>
+        /// Defines if timestamp should automatically be added to the json body when using Https
+        /// </summary>
+        public bool OmitTimestamp { get; set; }
+    }
+
+    public enum TransportProtocol
+    {
+        /// <summary>
+        /// Https.
+        /// </summary>
+        Https,
+
+        /// <summary>
+        /// SyslogSecure.
+        /// </summary>
+        SyslogSecure,
+
+        /// <summary>
+        /// SyslogUdp.
+        /// </summary>
+        SyslogUdp,
+
+        /// <summary>
+        /// SyslogTcp.
+        /// </summary>
+        SyslogTcp,
+    }
+}

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglyFormatter.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglyFormatter.cs
@@ -28,11 +28,11 @@ namespace Serilog.Sinks.Loggly
         readonly JsonSerializer _serializer = JsonSerializer.Create();
         readonly LogEventConverter _converter;
 
-        public LogglyFormatter(IFormatProvider formatProvider)
+        public LogglyFormatter(IFormatProvider formatProvider, LogIncludes includes)
         {
             //the converter should receive the format provider used, in order to 
             // handle dateTimes and dateTimeOffsets in a controlled manner
-            _converter = new LogEventConverter(formatProvider);
+            _converter = new LogEventConverter(formatProvider, includes);
         }
         public void Format(LogEvent logEvent, TextWriter output)
         {

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
@@ -47,6 +47,16 @@ namespace Serilog.Sinks.Loggly
         /// </summary>
         /// <param name="batchSizeLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
+        ///  <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>        
+        public LogglySink(IFormatProvider formatProvider, int batchSizeLimit, TimeSpan period) : this(formatProvider, batchSizeLimit, period, null, null)
+        {            
+        }
+
+        /// <summary>
+        /// Construct a sink that saves logs to the specified storage account. Properties are being send as data and the level is used as tag.
+        /// </summary>
+        /// <param name="batchSizeLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
         ///  <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="logglyConfig">Used to configure underlying LogglyClient programmaticaly. Otherwise use app.Config.</param>
         /// <param name="includes">Decides if the sink should include specific properties in the log message</param>

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
@@ -49,7 +49,8 @@ namespace Serilog.Sinks.Loggly
         /// <param name="period">The time to wait between checking for event batches.</param>
         ///  <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="logglyConfig">Used to configure underlying LogglyClient programmaticaly. Otherwise use app.Config.</param>
-        public LogglySink(IFormatProvider formatProvider, int batchSizeLimit, TimeSpan period, LogglyConfiguration logglyConfig)
+        /// <param name="includes">Decides if the sink should include specific properties in the log message</param>
+        public LogglySink(IFormatProvider formatProvider, int batchSizeLimit, TimeSpan period, LogglyConfiguration logglyConfig, LogIncludes includes)
             : base (batchSizeLimit, period)
         {
             if (logglyConfig != null)
@@ -58,7 +59,7 @@ namespace Serilog.Sinks.Loggly
                 _adapter.ConfigureLogglyClient(logglyConfig);
             }
             _client = new LogglyClient();
-            _converter = new LogEventConverter(formatProvider);
+            _converter = new LogEventConverter(formatProvider, includes);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
@@ -29,6 +29,7 @@ namespace Serilog.Sinks.Loggly
     {
         readonly LogEventConverter _converter;
         readonly LogglyClient _client;
+        readonly LogglyConfigAdapter _adapter;
 
         /// <summary>
         /// A reasonable default for the number of events posted in
@@ -47,9 +48,15 @@ namespace Serilog.Sinks.Loggly
         /// <param name="batchSizeLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         ///  <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        public LogglySink(IFormatProvider formatProvider, int batchSizeLimit, TimeSpan period)
+        /// <param name="logglyConfig">Used to configure underlying LogglyClient programmaticaly. Otherwise use app.Config.</param>
+        public LogglySink(IFormatProvider formatProvider, int batchSizeLimit, TimeSpan period, LogglyConfiguration logglyConfig)
             : base (batchSizeLimit, period)
         {
+            if (logglyConfig != null)
+            {
+                _adapter = new LogglyConfigAdapter();
+                _adapter.ConfigureLogglyClient(logglyConfig);
+            }
             _client = new LogglyClient();
             _converter = new LogEventConverter(formatProvider);
         }

--- a/test/Serilog.Sinks.Loggly.Tests/ExceptionSerialization.cs
+++ b/test/Serilog.Sinks.Loggly.Tests/ExceptionSerialization.cs
@@ -17,7 +17,7 @@ namespace Serilog.Sinks.Loggly.Tests
         public void ReturnFalseGivenValueOf1()
         {
             var writer = new StringWriter();
-            var formatter = new LogglyFormatter(null);
+            var formatter = new LogglyFormatter(null, null);
             try
             {
                 ThrowException();

--- a/test/Serilog.Sinks.Loggly.Tests/Serilog.Sinks.Loggly.Tests.csproj
+++ b/test/Serilog.Sinks.Loggly.Tests/Serilog.Sinks.Loggly.Tests.csproj
@@ -32,10 +32,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">


### PR DESCRIPTION
In order to configure the underlying LogglyClient when you don't have the possibility to (or just don't want to) use xml configuration, I've opened up the sink to use a configuration object if it is provided. 
If no object is provided, the current way of reading up the configuration is used.

Furthermore, I wanted to have the control over if I wanted to have the fields "Level", "Message", and "Exception" automatically added to log messages if not already present in the list of Serilog properties. 
So again opening up for passing in an object to do that. The change still defaults to how it is now, if no object is provided.