### PR TITLE
check for null bookmark before updating bookmark

### DIFF
--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/FileBufferDataProvider.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/FileBufferDataProvider.cs
@@ -174,7 +174,11 @@ namespace Serilog.Sinks.Loggly
                 //even if reading / deleteing files fails, we can / should update the bookmark file
                 //it is important that the file have the reset position, otherwise we risk failing to 
                 // move forward in the next read cycle
-                _bookmarkProvider.UpdateBookmark(_currentBookmark);
+                //it's possible that no bookmark exists, especially if no valid messages have forced a 
+                // durable log file to be created. In this case, the bookmark file will be empty and 
+                // on disk
+                if(_currentBookmark != null)
+                    _bookmarkProvider.UpdateBookmark(_currentBookmark);
             }
         }
 


### PR DESCRIPTION
This has been found to occur if a program only generates a message(s) of a level that is not sent to the remote server (such as debug messages when the info level is the minimum). In this case, the bookmark file will exist on disk but be empty, and no messages will have been persisted on disk. The periodic check will fail in the UpdateBookmark call since no bookmark exists (null)