### PR TITLE
add minor xunit related fixes

### DIFF
--- a/test/Serilog.Sinks.Loggly.Tests/Serilog.Sinks.Loggly.Tests.csproj
+++ b/test/Serilog.Sinks.Loggly.Tests/Serilog.Sinks.Loggly.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Loggly.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -33,14 +33,17 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <Reference Include="System.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.Loggly.Tests/Sinks/Loggly/FileBufferDataProviderTests.cs
+++ b/test/Serilog.Sinks.Loggly.Tests/Sinks/Loggly/FileBufferDataProviderTests.cs
@@ -583,7 +583,7 @@ namespace Serilog.Sinks.Loggly.Tests.Sinks.Loggly
 
                 [Fact]
                 public void SingleFileShouldHaveBeenDeleted() =>
-                    Assert.Equal(1, _deletedFiles.Count);
+                    Assert.Single(_deletedFiles);
             }
 
             public class RetentionLimitLessThenLimitNumberOfBufferFiles


### PR DESCRIPTION
Assert.Equal is not recommended to check the size collection so that has changes to Assert.Single.
Added a System.Core ref in the net452 test run context to avoid failures in tests (runner was trying to load System.Core to access the exception.StackTrace property)
Added netcoreapp2.0 target in the test project to run in that context (and check if the System.Core ref was required in it).