### PR TITLE
Upgrade loggly-csharp dependency

### DIFF
--- a/sample/sampleDurableLogger/sampleDurableLogger.csproj
+++ b/sample/sampleDurableLogger/sampleDurableLogger.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="loggly-csharp" Version="4.6.1.45" />
+    <PackageReference Include="loggly-csharp" Version="4.6.1.55" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />

--- a/src/Serilog.Sinks.Loggly/Serilog.Sinks.Loggly.csproj
+++ b/src/Serilog.Sinks.Loggly/Serilog.Sinks.Loggly.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="loggly-csharp" Version="4.6.1.45" />
+    <PackageReference Include="loggly-csharp" Version="4.6.1.55" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />


### PR DESCRIPTION
Upgrade the loggly-csharp version to include a possible important fix with missing `ConfigureAwait` on the HttpTransport.

https://github.com/neutmute/loggly-csharp/pull/72