### PR TITLE
Added better error handling in LogglySink

### DIFF
--- a/sample/sampleDurableLogger/sampleDurableLogger.csproj
+++ b/sample/sampleDurableLogger/sampleDurableLogger.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
-    <PackageReference Include="Serilog.Sinks.RollingFileAlternate" Version="2.0.9.1" />
+    <PackageReference Include="Serilog.Sinks.RollingFileAlternate" Version="2.0.9" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
@@ -81,23 +81,16 @@ namespace Serilog.Sinks.Loggly
         /// not both.</remarks>
         protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
-            try
-            {
-                LogResponse response = await _client.Log(events.Select(_converter.CreateLogglyEvent)).ConfigureAwait(false);
+            LogResponse response = await _client.Log(events.Select(_converter.CreateLogglyEvent)).ConfigureAwait(false);
 
-                switch (response.Code)
-                {
-                    case ResponseCode.Error:
-                        SelfLog.WriteLine("LogglySink received an Error response: {0}", response.Message);
-                        break;
-                    case ResponseCode.Unknown:
-                        SelfLog.WriteLine("LogglySink received an Unknown response: {0}", response.Message);
-                        break;
-                }
-            }
-            catch (Exception ex)
+            switch (response.Code)
             {
-                SelfLog.WriteLine("LogglySink encountered an exception: {0}", ex);
+                case ResponseCode.Error:
+                    SelfLog.WriteLine("LogglySink received an Error response: {0}", response.Message);
+                    break;
+                case ResponseCode.Unknown:
+                    SelfLog.WriteLine("LogglySink received an Unknown response: {0}", response.Message);
+                    break;
             }
         }
         

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Loggly;
+using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
 
@@ -80,7 +81,24 @@ namespace Serilog.Sinks.Loggly
         /// not both.</remarks>
         protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
-            await _client.Log(events.Select(_converter.CreateLogglyEvent));
+            try
+            {
+                LogResponse response = await _client.Log(events.Select(_converter.CreateLogglyEvent)).ConfigureAwait(false);
+
+                switch (response.Code)
+                {
+                    case ResponseCode.Error:
+                        SelfLog.WriteLine("LogglySink received an Error response: {0}", response.Message);
+                        break;
+                    case ResponseCode.Unknown:
+                        SelfLog.WriteLine("LogglySink received an Unknown response: {0}", response.Message);
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                SelfLog.WriteLine("LogglySink encountered an exception: {0}", ex);
+            }
         }
         
     }


### PR DESCRIPTION
Updated the `EmitBatchAsync` method in `LogglySink` to handle potential exceptions and evaluate the `LogResponse` when calling the `Log` method of the `LogglyClient`.  It now writes to `SelfLog` when problems occur to enable easier debugging.

I believe this may help with the problems described in #39.

Also removed a digit from the `PackageReference` for `Serilog.Sinks.RollingFileAlternate` in **sampleDurableLogger.csproj** to get local builds working.